### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TechBlurbs/maandamano-mondays-sentiment-analysis/security/code-scanning/1](https://github.com/TechBlurbs/maandamano-mondays-sentiment-analysis/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow. Since the workflow only reads repository contents (e.g., installing dependencies and analyzing code), the minimal permission `contents: read` is sufficient. This change ensures the workflow adheres to the principle of least privilege and avoids unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
