### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/TechBlurbs/maandamano-mondays-sentiment-analysis/security/code-scanning/3](https://github.com/TechBlurbs/maandamano-mondays-sentiment-analysis/security/code-scanning/3)

In general, this problem is fixed by adding an explicit `permissions` block either at the workflow root (applies to all jobs) or within the specific job, granting only the minimal required scopes (typically `contents: read` for a read-only CI job). For this pylint workflow, no step needs to write to the repository, issues, or pull requests; it only checks out code and runs tools locally. Therefore, the safest minimal permission is `contents: read`.

The best fix with no change to existing functionality is to add a `permissions` block at the top level of `.github/workflows/pylint.yml`, directly under the `name:` line (or equivalently just under `on:`), setting `contents: read`. This will apply to the `build` job and any future jobs that don’t override permissions. No additional imports, tools, or code changes are needed; GitHub Actions natively supports the `permissions` key.

Concretely: edit `.github/workflows/pylint.yml` so that after line 1 (`name: Pylint`) you insert:

```yaml
permissions:
  contents: read
```

All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
